### PR TITLE
Depend on modern Ubic::Service::Plack

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,3 @@
-
 use strict;
 use warnings;
 
@@ -24,7 +23,7 @@ my %WriteMakefileArgs = (
   "LICENSE" => "unrestricted",
   "NAME" => "Ubic::Service::Starman",
   "PREREQ_PM" => {
-    "Ubic::Service::Plack" => 0,
+    "Ubic::Service::Plack" => "1.13",
     "base" => 0,
     "strict" => 0,
     "warnings" => 0


### PR DESCRIPTION
`Ubic::Service::Starman` uses `->pidfile` method, which got introduced in 1.13 version of `Ubic::Service::Plack`.
One guy just got `Can't locate object method` error message and couldn't figure it out :)
